### PR TITLE
Add route to expose cities of a country in main.py

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -31,6 +31,12 @@ def countries():
     return list(data.keys())
 
 
+# Create a new route that exposes the cities of a country
+@app.get('/countries/{country}')
+def cities(country: str):
+    return list(data[country].keys())
+
+
 @app.get('/countries/{country}/{city}/{month}')
 def monthly_average(country: str, city: str, month: str):
     return data[country][city][month]

--- a/webapp/test_main.py
+++ b/webapp/test_main.py
@@ -4,6 +4,14 @@ from fastapi.testclient import TestClient
 client = TestClient(app)
 
 
+expected_data = {
+    "Italy": {
+        "Rome": {
+            "January": {"high": 50, "low": 32}
+        }
+    }
+}
+
 def test_root():
     response = client.get("/")
     assert response.status_code == 200
@@ -13,3 +21,13 @@ def test_countries():
     response = client.get("/countries")
     assert response.status_code == 200
     assert sorted(response.json()) == ["England", "France", "Germany", "Italy", "Peru", "Portugal", "Spain"]
+
+def test_cities():
+    response = client.get("/countries/Italy")
+    assert response.status_code == 200
+    assert sorted(response.json()) == ["Milan", "Rome"]
+
+def test_monthly_average():
+    response = client.get("/countries/Italy/Rome/January")
+    assert response.status_code == 200
+    assert response.json() == expected_data["Italy"]["Rome"]["January"]


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `webapp` application, allowing users to fetch a list of cities for a given country. This is implemented through a new route in the `main.py` file. Accompanying changes have been made to the test suite in the `test_main.py` file to validate the functionality of this new route.

New feature implementation:

* [`webapp/main.py`](diffhunk://#diff-a1c285b6578b541d130dde4fa7fe2a44f7ce2d8bcb91078241cdc58cc087ab40R34-R39): Added a new route `/countries/{country}` to the application. This route returns a list of cities for a given country.

Test suite updates:

* [`webapp/test_main.py`](diffhunk://#diff-8f5cf2c1c139c259980800b1d2367498fe4d1026334610404f99c727c2cb8d2eR7-R14): Added `expected_data` dictionary to use in the test cases.
* [`webapp/test_main.py`](diffhunk://#diff-8f5cf2c1c139c259980800b1d2367498fe4d1026334610404f99c727c2cb8d2eR24-R33): Added new test cases `test_cities()` and `test_monthly_average()`. The `test_cities()` test case validates the new route by checking if it correctly returns the cities for a given country. The `test_monthly_average()` test case checks if the route `/countries/{country}/{city}/{month}` correctly returns the average temperature for a given city in a specific month.